### PR TITLE
Return the ServiceProviderProfile object directly instead of mapping …

### DIFF
--- a/src/main/java/petitus/petcareplus/service/ServiceProviderProfileService.java
+++ b/src/main/java/petitus/petcareplus/service/ServiceProviderProfileService.java
@@ -184,7 +184,7 @@ public class ServiceProviderProfileService {
         ServiceProviderProfile serviceProviderProfile = serviceProviderProfileRepository.findByUserIdWithAllRelations(userId)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         messageSourceService.get("service_provider_profile_not_found")));
-        return mapToServiceProviderProfileResponse(serviceProviderProfile);
+        return serviceProviderProfile;
     }
 
     private ServiceProviderProfileResponse mapToServiceProviderProfileResponse(


### PR DESCRIPTION
…to a response in the service provider profile retrieval method.